### PR TITLE
Update opyrability.py

### DIFF
--- a/src/opyrability.py
+++ b/src/opyrability.py
@@ -166,7 +166,7 @@ def multimodel_rep(model: Callable[...,Union[float,np.ndarray]],
         # Reshape (n^k, k) vectors into (list[k*n, k]) multidimensional arrays. 
         # This makes polytopic tracing calculations more "clear". 
         AIS = AIS.reshape((resolution + [AIS.shape[-1]]))
-        AOS = AIS.reshape((resolution + [AOS.shape[-1]]))
+        AOS = AOS.reshape((resolution + [AOS.shape[-1]]))
     
     # Switch in between for simplicial of polyhedra calculations.
     if  polytopic_trace  =='simplices':


### PR DESCRIPTION
While reviewing the code in opyrability.py, I noticed a potential typo that may cause issues, particularly in the inverse operability computation.

At line 169 (opyrability.py), the following reshaping operation is implemented:

AOS = AIS.reshape((resolution + [AOS.shape[-1]]))

However, based on the surrounding logic and the intended behavior, it seems that AOS is being reshaped using AIS by mistake. I believe the correct implementation should be:

AOS = AOS.reshape((resolution + [AOS.shape[-1]]))

This appears to be a small typo, but it could lead to incorrect behavior or silent errors when working with the inverse mapping.

Please let me know if this interpretation makes sense or if there is a specific reason for reshaping AOS from AIS at this point.

Best regards,
Nicolas Spogis
AI4Tech