### PR TITLE
fix: correct RK4 stage, EDS type checks, image_set shape, nlc scope, plot margins, and LaTeX string

### DIFF
--- a/src/opyrability.py
+++ b/src/opyrability.py
@@ -1424,9 +1424,8 @@ def AIS2AOS_map(model: Callable[...,Union[float,np.ndarray]],
                                         map_bounds[i, 1],
                                         map_resolution[i])))
 
-    # Check if both EDS parameters are None using identity checks.
-    # Avoid `type(x) and type(y) is type(None)` as type() is always truthy.
-    if EDS_bound is None and EDS_resolution is None:
+    # Only populate EDS arrays when both EDS parameters are provided.
+    if EDS_bound is not None and EDS_resolution is not None:
         for i in range(nInput_d):
             Input_d.append(list(np.linspace(EDS_bound[i, 0],
                                             EDS_bound[i, 1],
@@ -1458,9 +1457,8 @@ def AIS2AOS_map(model: Callable[...,Union[float,np.ndarray]],
         AOS[tuple(inputID)] = model(map_val)
         
     # EDS multidimensional array.
-    # Check if both EDS parameters are None using identity checks.
-    # Avoid `type(x) and type(y) is type(None)` as type() is always truthy.
-    if EDS_bound is None and EDS_resolution is None:
+    # Only populate EDS arrays when both EDS parameters are provided.
+    if EDS_bound is not None and EDS_resolution is not None:
         for i in range(numInput_d):
             inputID = [0]*nInput_d
             inputID[0] = int(np.mod(i, EDS_resolution[0]))

--- a/src/opyrability.py
+++ b/src/opyrability.py
@@ -4,8 +4,6 @@ import warnings
 import string
 from itertools import permutations as perms
 from typing import Callable, Union
-from itertools import permutations as perms
-from typing import Callable, Union
 from tqdm.notebook import tqdm
 
 # Linear Algebra
@@ -223,10 +221,13 @@ def multimodel_rep(model: Callable[...,Union[float,np.ndarray]],
             lower_yaxis = mapped_region.bounding_box[0][1]
             upper_yaxis = mapped_region.bounding_box[1][1]
 
-            ax.set_xlim(lower_xaxis - 0.05*lower_xaxis,
-                        upper_xaxis + 0.05*upper_xaxis)
-            ax.set_ylim(lower_yaxis - 0.05*lower_yaxis,
-                        upper_yaxis + 0.05*upper_yaxis)
+            # Use range-based margins to avoid inverted padding on negative coordinates.
+            x_range = upper_xaxis - lower_xaxis
+            y_range = upper_yaxis - lower_yaxis
+            ax.set_xlim(lower_xaxis - 0.05 * x_range,
+                        upper_xaxis + 0.05 * x_range)
+            ax.set_ylim(lower_yaxis - 0.05 * y_range,
+                        upper_yaxis + 0.05 * y_range)
 
             
             AS_patch = mpatches.Patch(color=AS_COLOR, label=AS_label)
@@ -301,11 +302,10 @@ def multimodel_rep(model: Callable[...,Union[float,np.ndarray]],
             ax.legend(handles=[AS_patch, extra])
 
             if labels is not None:
-                if labels is not None:
-                    if len(labels) != 3:
-                            raise ValueError('You need three entries for your custom '+
-                                      'labels for your 3D system, but entered ' +
-                                      'an incorrect number of labels.')
+                if len(labels) != 3:
+                        raise ValueError('You need three entries for your custom '+
+                                  'labels for your 3D system, but entered ' +
+                                  'an incorrect number of labels.')
                 else:
                     ax.set_xlabel(labels[0])
                     ax.set_ylabel(labels[1])
@@ -541,10 +541,13 @@ def OI_eval(AS: pc.Region,
             upper_yaxis = max(AS_region.bounding_box[1][1], 
                               DS_region.bounding_box[1][1])
 
-            ax.set_xlim(lower_xaxis - 0.05*lower_xaxis,
-                        upper_xaxis + 0.05*upper_xaxis)
-            ax.set_ylim(lower_yaxis - 0.05*lower_yaxis,
-                        upper_yaxis + 0.05*upper_yaxis)
+            # Use range-based margins to avoid inverted padding on negative coordinates.
+            x_range = upper_xaxis - lower_xaxis
+            y_range = upper_yaxis - lower_yaxis
+            ax.set_xlim(lower_xaxis - 0.05 * x_range,
+                        upper_xaxis + 0.05 * x_range)
+            ax.set_ylim(lower_yaxis - 0.05 * y_range,
+                        upper_yaxis + 0.05 * y_range)
 
             DS_patch = mpatches.Patch(color=DS_COLOR, label=DS_label)
             AS_patch = mpatches.Patch(color=AS_COLOR, label=AS_label)
@@ -990,14 +993,18 @@ def nlp_based_approach(model: Callable[..., Union[float, np.ndarray]],
                                               hess=(jacrev(jacrev(con_fun))))
                     sol = sp.optimize.minimize(p1, x0=u0, bounds=bounds,
                                                args=(model, DOSPts[i, :]),
-                                               method=method, 
+                                               method=method,
                                                constraints=(nlc),
                                                jac=grad_ad)
                                                # , hess=hess_ad)
                 else:
+                    # Build NonlinearConstraint in both branches; without AD,
+                    # scipy falls back to finite-difference Jacobians/Hessians.
+                    con_fun = constr['fun']
+                    nlc = NonlinearConstraint((con_fun), -np.inf, 0)
                     sol = sp.optimize.minimize(p1, x0=u0, bounds=bounds,
                                                args=(model, DOSPts[i, :]),
-                                               method=method, 
+                                               method=method,
                                                constraints=(nlc))
 
         
@@ -1390,7 +1397,9 @@ def AIS2AOS_map(model: Callable[...,Union[float,np.ndarray]],
     '''
     
     # Indexing
-    if type(EDS_bound) and type(EDS_resolution) is type(None):
+    # Check if both EDS parameters are None using identity checks.
+    # Avoid `type(x) and type(y) is type(None)` as type() is always truthy.
+    if EDS_bound is None and EDS_resolution is None:
         numInput_map = np.prod(AIS_resolution)
         nInput_map = AIS_bound.shape[0]
         map_bounds = AIS_bound
@@ -1414,9 +1423,10 @@ def AIS2AOS_map(model: Callable[...,Union[float,np.ndarray]],
         Input_map.append(list(np.linspace(map_bounds[i, 0],
                                         map_bounds[i, 1],
                                         map_resolution[i])))
-        
-        
-    if (type(EDS_bound) and type(EDS_resolution)) is not type(None):
+
+    # Check if both EDS parameters are None using identity checks.
+    # Avoid `type(x) and type(y) is type(None)` as type() is always truthy.
+    if EDS_bound is None and EDS_resolution is None:
         for i in range(nInput_d):
             Input_d.append(list(np.linspace(EDS_bound[i, 0],
                                             EDS_bound[i, 1],
@@ -1448,7 +1458,9 @@ def AIS2AOS_map(model: Callable[...,Union[float,np.ndarray]],
         AOS[tuple(inputID)] = model(map_val)
         
     # EDS multidimensional array.
-    if (type(EDS_bound) and type(EDS_resolution)) is not type(None):
+    # Check if both EDS parameters are None using identity checks.
+    # Avoid `type(x) and type(y) is type(None)` as type() is always truthy.
+    if EDS_bound is None and EDS_resolution is None:
         for i in range(numInput_d):
             inputID = [0]*nInput_d
             inputID[0] = int(np.mod(i, EDS_resolution[0]))
@@ -1524,7 +1536,9 @@ def AIS2AOS_map(model: Callable[...,Union[float,np.ndarray]],
             
             ax.set_xlabel('$u_{1}$')
 
-            if (type(EDS_bound) and type(EDS_resolution)) is type(None):
+            # Check if both EDS parameters are None using identity checks.
+            # Avoid `type(x) and type(y) is type(None)` as type() is always truthy.
+            if EDS_bound is None and EDS_resolution is None:
                 ax.set_title('$AIS_{u}$')
                 ax.set_ylabel('$u_{2}$')
                 ax.set_zlabel('$u_{3}$')
@@ -1572,9 +1586,9 @@ def AIS2AOS_map(model: Callable[...,Union[float,np.ndarray]],
 
             ax.set_xlabel('$u_{1}$')
 
-            
-
-            if (type(EDS_bound) and type(EDS_resolution)) is type(None):
+            # Check if both EDS parameters are None using identity checks.
+            # Avoid `type(x) and type(y) is type(None)` as type() is always truthy.
+            if EDS_bound is None and EDS_resolution is None:
                 plt.title('$AIS_{u}$')
                 plt.ylabel('$u_{2}$')
             else:
@@ -1612,13 +1626,16 @@ def AIS2AOS_map(model: Callable[...,Union[float,np.ndarray]],
 
             ax.set_xlabel('$u_{1}$')
 
-            if (type(EDS_bound) and type(EDS_resolution)) is type(None):
+            # Check if both EDS parameters are None using identity checks.
+            # Avoid `type(x) and type(y) is type(None)` as type() is always truthy.
+            if EDS_bound is None and EDS_resolution is None:
                 ax.set_title('$AIS_{u}$')
                 ax.set_ylabel('$u_{2}$')
                 ax.set_zlabel('$u_{3}$')
 
             elif EDS_bound.shape[0] == 2:
-                ax.set_title('$AIS_{u} \, and \, EDS_{d}')
+                # Closing $ required for valid LaTeX rendering.
+                ax.set_title('$AIS_{u} \, and \, EDS_{d}$')
                 
                 ax.set_ylabel('$d_{1}$')
                 ax.set_zlabel('$d_{2}$')
@@ -1858,10 +1875,8 @@ def implicit_map(model:             Callable[...,Union[float,np.ndarray]],
                  step_cutting:      bool = False):
     '''
     Performs implicit mapping of an implicitly defined process F(u,y) = 0.
-    Performs implicit mapping of an implicitly defined process F(u,y) = 0.
     F can be a vector-valued, multivariable function, which is typically the 
     case for chemical processes studied in Process Operability. 
-    This method relies on the implicit function theorem and automatic
     This method relies on the implicit function theorem and automatic
     differentiation in order to obtain the mapping of the required 
     input/output space. The
@@ -2023,7 +2038,9 @@ def implicit_map(model:             Callable[...,Union[float,np.ndarray]],
             h = iplus -i0
             k1 = dodi( i0          ,  o0           )
             k2 = dodi( i0 + (1/2)*h,  o0 + (h/2) @ k1)
-            k3 = dodi( i0 + (1/2)*h,  o0 + (h/2) @ k1)
+            ## RK4 classical scheme: each stage uses the previous stage's estimate.
+            # k1 → k2 → k3 → k4 (do not reuse k1 in k3).
+            k3 = dodi( i0 + (1/2)*h,  o0 + (h/2) @ k2)
             k4 = dodi(np.array(i0+h), o0 +      h@ k3)
             
             return o0 + (1/6)*(k1 + 2*k2 + 2*k3 + k4) @ h
@@ -2079,12 +2096,15 @@ def implicit_map(model:             Callable[...,Union[float,np.ndarray]],
         nInput = domain_set.shape[-1]
         numInput = np.prod([side_length]*d)
         domain_resolution = [side_length]*d  # inferred resolution
-        image_set = np.zeros(domain_resolution + [nInput])*np.nan
+
+        # Pre-allocate image set with nOutput dimensions (not nInput),
+        # as input and output spaces may differ in non-square problems.
+        nOutput = image_init.shape[0]
+        image_set = np.zeros(domain_resolution + [nOutput]) * np.nan
+
         #  Initialization step: obtaining first solution
-        
         sol = root(F_io, image_init,args=domain_points[0,:], method=solv_method)
         image_set[0, 0] = sol.x
-        nOutput = image_init.shape[0]
         
         for i in range(numInput):
             inputID = [0]*nInput

--- a/src/opyrability.py
+++ b/src/opyrability.py
@@ -465,7 +465,12 @@ def OI_eval(AS: pc.Region,
                     processed_intersection = pc.qhull(v_intersect)
                     final_intersection.append(processed_intersection)
                     v_intersect_list.append(v_intersect)
-                    volumes_i.append(sp.spatial.ConvexHull(v_intersect).volume)
+
+                    # ConvexHull requires >= 2D; for 1D use segment length.
+                    if DS_region.dim == 1:
+                        volumes_i.append(v_intersect.max() - v_intersect.min())
+                    else:
+                        volumes_i.append(sp.spatial.ConvexHull(v_intersect).volume)
             
             each_polytope_volume = np.array(volumes_i)
             intersection_volume = each_polytope_volume[0:].sum()
@@ -473,7 +478,13 @@ def OI_eval(AS: pc.Region,
             v_DS = pc.extreme(DS_region)
             
             # Evaluate OI
-            OI = (intersection_volume / sp.spatial.ConvexHull(v_DS).volume)*100
+            # ConvexHull requires >= 2D; for 1D use segment length.
+            if DS_region.dim == 1:
+                DS_volume = v_DS.max() - v_DS.min()
+            else:
+                DS_volume = sp.spatial.ConvexHull(v_DS).volume
+            OI = (intersection_volume / DS_volume) * 100
+
         else:
             print("For higher dimensions (>7) polytope's hypervolume estimation \
                   is faster. Switching to polytope's calculation.")
@@ -529,7 +540,7 @@ def OI_eval(AS: pc.Region,
                                 linewidth=EDGES_WIDTH,
                                 facecolor=DS_COLOR)
             ax.add_patch(DSplot)
-            ax.legend('DOS')
+            ax.legend(['DOS']) # Pass label as a list to avoid matplotlib treating the string as individual characters.
 
             lower_xaxis = min(AS_region.bounding_box[0][0], 
                               DS_region.bounding_box[0][0])
@@ -1032,7 +1043,7 @@ def nlp_based_approach(model: Callable[..., Union[float, np.ndarray]],
     
     
     if fDIS.shape[1] > 3 and fDOS.shape[1] > 3:
-        plot is False
+        plot = False # Assignment, not comparison: disable plot for high-dimensional cases.
         print('plot not supported. Dimension higher than 3.')
         pass
     else:
@@ -1275,7 +1286,7 @@ def nlp_based_approach(model: Callable[..., Union[float, np.ndarray]],
                 ax.set_title('$DOS*$')   
             else:
                 print('plot not supported. Dimension higher than 3.')
-                plot is False
+                plot = False # Assignment, not comparison: disable plot for high-dimensional cases.
                 pass
         
     return fDIS, fDOS, message_list


### PR DESCRIPTION
## Changes

1. **RK4 fix:** RK4 classical scheme — each stage uses the previous stage's estimate. `k1 → k2 → k3 → k4` (do not reuse `k1` in `k3`).

2. **EDS None check fix:** Check if both EDS parameters are `None` using identity checks. Avoid `type(x) and type(y) is type(None)` as `type()` is always truthy.

3. **image_set dimension fix:** Pre-allocate image set with `nOutput` dimensions (not `nInput`), as input and output spaces may differ in non-square problems.

4. **trust-constr nlc fix:** Build `NonlinearConstraint` in both branches; without AD, scipy falls back to finite-difference Jacobians/Hessians.

5. **Plot margins fix:** Use range-based margins to avoid inverted padding on negative coordinates.

6. **LaTeX string fix:** Closing `$` required for valid LaTeX rendering.