### PR TITLE
Handle empty intersection in OI_eval to prevent crash

### DIFF
--- a/src/opyrability.py
+++ b/src/opyrability.py
@@ -425,7 +425,11 @@ def OI_eval(AS: pc.Region,
             pass
         else:
             inter_list.append(intersection)
-            
+
+    if len(inter_list) == 0:
+        print('No intersection found between AS and DS. OI = 0.')
+        return 0.0
+
     overlapped_intersection = pc.Region(inter_list)
     min_coord =  overlapped_intersection.bounding_box[0]
     max_coord =  overlapped_intersection.bounding_box[1]


### PR DESCRIPTION
## Summary
- Return OI = 0 early in `OI_eval` when AS and DS regions have no overlap
- Previously, an empty intersection caused a crash in the polytope library when trying to compute the bounding box of an empty `pc.Region([])`
- This also unblocks future 1D OI evaluation support (PR #34)

## Test plan
- [x] All 4 existing tests pass
- [x] New scenario: non-overlapping AS/DS returns OI = 0.0 (previously crashed)
- [x] Normal overlap scenario still returns correct OI (~60.24)
